### PR TITLE
Ability to time travel to past snapshots

### DIFF
--- a/src/app/components/App.jsx
+++ b/src/app/components/App.jsx
@@ -1,14 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import MainContainer from '../Containers/MainContainer';
 
+const LOGO_URL = 'https://qv7zda.bl.files.1drv.com/y4pJcCvhYCZvfPcG6U2qdGZKhwllRCJvQk6z1L-zbgkjShAOfOfMGJUtogwnYwutjqIgWOkDHrSWM93rs5UeEdzSuI7qM_PjBjGGZneuUgguzBk50aXWt2z4m4xOO8y2plDiu9cLLLmYDf3uYsuAUQHDuhypvDDlp0fsYsvy1M0lVwwHt3lqul_h-UXjkzVMMnLCHFUkeSGwLnWp6aBVL9oU5S_XooGyVS2MuUf1WolE9I/Recoilize.png?psid=1'
+
 function App() {
   const [snapshotHistory, setSnapshotHistory] = useState([]);
 
   useEffect(() => {
     // SETUP connection to bg script
-    const backgroundConnection = chrome.runtime.connect({
-      name: 'panel',
-    });
+    const backgroundConnection = chrome.runtime.connect();
 
     console.log('backgroundConnection: ', backgroundConnection)
     // INITIALIZE connection to bg script
@@ -24,13 +24,27 @@ function App() {
     });
   }, []);
 
-  return (
-    <div className='App'>
+  // Render main container if we have detected a recoil app with the recoilize module passing data
+  const renderMainContainer = () => {
+    return (
       <MainContainer
         className='mainContainer'
         // array of snapshots
         snapshots={snapshotHistory}
       />
+    )
+  }
+
+  // Render module not found message if snapHistory is null, this means we have not detected a recoil app with recoilize module installed properly
+  const renderModuleNotFoundContainer = () => {
+    return (
+      <div className='notFoundContainer'><img className='logo' src={LOGO_URL} /><p>Supported only with Recoil apps with the Recoilize NPM module. Follow the installation instructions at www.recoilize.com.</p></div>
+    )
+  }
+
+  return (
+    <div className='App'>
+      {snapshotHistory ? renderMainContainer() : renderModuleNotFoundContainer()}
     </div>
   );
 }

--- a/src/app/components/App.jsx
+++ b/src/app/components/App.jsx
@@ -9,10 +9,12 @@ function App() {
     const backgroundConnection = chrome.runtime.connect({
       name: "panel",
     });
+
+    console.log('backgroundConnection: ', backgroundConnection)
     // INITIALIZE connection to bg script
     backgroundConnection.postMessage({
       action: "devToolInitialized",
-      tabId: chrome.devtools.inspectedWindow.tabId,
+      tabId: chrome.devtools.inspectedWindow.tabId
     });
     // LISTEN for messages FROM bg script
     backgroundConnection.onMessage.addListener((msg) => {

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -22,20 +22,38 @@ chrome.runtime.onConnect.addListener(port => {
     console.log('in the devToolsListener')
     console.log('the msg: ', msg);
 
-    if (msg.action === 'devToolInitialized' && msg.tabId){
-      connections[msg.tabId] = port;
+    const { tabId, action } = msg;
 
-      // * DEBUGGING MESSAGES *
-      console.log('port connect, these are the other current connections:', connections);
+    switch (action) {
+      case 'devToolInitialized': 
+        connections[tabId] = port;
 
-      // read and send back to dev tool current local storage for corresponding tabId & port
-      chrome.storage.local.get(null, function(result) {
-        connections[msg.tabId].postMessage({
-          action: 'recordSnapshot',
-          payload: result[msg.tabId]
+        // * DEBUGGING MESSAGES *
+        console.log('port connect, these are the other current connections:', connections);
+
+        // read and send back to dev tool current local storage for corresponding tabId & port
+        chrome.storage.local.get(null, function(result) {
+          connections[tabId].postMessage({
+            action: 'recordSnapshot',
+            payload: result[tabId]
+          });
         });
-      });
-      
+        break;
+
+      case 'snapshotTimeTravel':
+        // * DEBUGGING MESSAGES *
+        console.log('snapshotTimeTravel request has been received from dev tool: ', msg);
+
+        if (tabId) {
+          // if msg tabId provided, send time travel snapshot history to content-script
+          chrome.tabs.sendMessage(tabId, msg);
+        } else {
+          console.log('ERROR: no tabId was sent with this request');
+        }
+        break;
+
+      default:
+        break;
     }
   }
 
@@ -71,73 +89,81 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
   // Grabs tab id from content script and converts it to a string
   const tabId = `${sender.tab.id}`;
 
-  // Listens to new snapshots (state changes) from module, stores in local storage and sends to dev tool if port is opened
-  if (msg.action === 'recordSnapshot') {
-    
-    // Next snapshot from the msg payload
-    const snapshot = msg.payload;
+  const { action } = msg;
 
-    // * DEBUGGING MESSAGES *
-    chrome.storage.local.get(null, function(result) {
-      console.log('storage for whole local currently is ' + JSON.stringify(result));
-    })
+  switch (action) {
     
-    // Get current snapshot history from local storage
-    chrome.storage.local.get([tabId], function(result) {
+    // Listens to new snapshots (state changes) from module, stores in local storage and sends to dev tool if port is opened
+    case 'recordSnapshot':
+      // Next snapshot from the msg payload
+      const snapshot = msg.payload;
 
       // * DEBUGGING MESSAGES *
-      console.log('storage for tabId currently is ' + JSON.stringify(result));
+      chrome.storage.local.get(null, function(result) {
+        console.log('storage for whole local currently is ' + JSON.stringify(result));
+      })
       
-      // Grab the current snapshot history from local storage
-      const tabIdSnapshotHistory = result[tabId] ? [...result[tabId]] : [];
+      // Get current snapshot history from local storage
+      chrome.storage.local.get([tabId], function(result) {
 
-      // Grab the last (most recent) snapshot from the history
-      const lastSnapshot = tabIdSnapshotHistory.length > 0 ?  tabIdSnapshotHistory[tabIdSnapshotHistory.length - 1] : {}
-
-      // Merge the changed atoms from the new state with the old state
-      // the old state should have the list of ALL atoms, not just the ones that changed, so we want to preserve a list of all atoms.
-      tabIdSnapshotHistory.push(Object.assign({}, lastSnapshot, snapshot));
-  
-      // Set local storage with updated snapshotHistory
-      chrome.storage.local.set({[tabId]: tabIdSnapshotHistory}, function() {
-        console.log('Local storage "snapshotHistory" is set to ' + tabIdSnapshotHistory);
+        // * DEBUGGING MESSAGES *
+        console.log('storage for tabId currently is ' + JSON.stringify(result));
         
-        // ONLY if there is a port connection with the current tabId
-        if (connections[tabId]) {
-          console.log(`sending message to port ${tabId}. msg payload sent: `, msg.payload)
+        // Grab the current snapshot history from local storage
+        const tabIdSnapshotHistory = result[tabId] ? [...result[tabId]] : [];
 
-          // Send to dev tool
+        // Grab the last (most recent) snapshot from the history
+        const lastSnapshot = tabIdSnapshotHistory.length > 0 ?  tabIdSnapshotHistory[tabIdSnapshotHistory.length - 1] : {}
+
+        // Merge the changed atoms from the new state with the old state
+        // the old state should have the list of ALL atoms, not just the ones that changed, so we want to preserve a list of all atoms.
+        tabIdSnapshotHistory.push(Object.assign({}, lastSnapshot, snapshot));
+    
+        // Set local storage with updated snapshotHistory
+        chrome.storage.local.set({[tabId]: tabIdSnapshotHistory}, function() {
+          console.log('Local storage "snapshotHistory" is set to ' + tabIdSnapshotHistory);
+          
+          // ONLY if there is a port connection with the current tabId
+          if (connections[tabId]) {
+            console.log(`sending message to port ${tabId}. msg payload sent: `, msg.payload)
+
+            // Send to dev tool
+            connections[tabId].postMessage({
+              action: 'recordSnapshot',
+              payload: tabIdSnapshotHistory,
+            });
+          
+          } else { // Error message if port does not exist
+            console.log(`error: Tab, ${tabId}, not found in connection list: ${connections}`)
+          }
+        });
+      });
+      break;
+
+    // If the module is loaded for first time or refreshed reset snapshot History and send initial payload
+    case 'moduleInitialized':
+      const tabIdSnapshotHistory = [msg.payload]
+
+      // set tabId within local storage to initial snapshot sent from module
+      chrome.storage.local.set({[tabId]: tabIdSnapshotHistory}, function() {
+        console.log('Local storage "snapshotHistory" is set to ' + JSON.stringify(tabIdSnapshotHistory));
+        
+        // if tabId is has opened dev tool port, send snapshotHistory to dev tool.
+        if (connections[tabId]) {
+          console.log(`sending message to port ${tabId}. msg payload sent: `, JSON.stringify(tabIdSnapshotHistory))
           connections[tabId].postMessage({
             action: 'recordSnapshot',
             payload: tabIdSnapshotHistory,
           });
-        
-        } else { // Error message if port does not exist
+        } else {
+          // Tells content script that connection was not made
           console.log(`error: Tab, ${tabId}, not found in connection list: ${connections}`)
         }
       });
-    });
-  } 
+      break;
 
-  // If the module is loaded for first time or refreshed reset snapshot History and send initial payload
-  if (msg.action === 'moduleInitialized') {
-
-    const tabIdSnapshotHistory = [msg.payload]
-
-    chrome.storage.local.set({[tabId]: tabIdSnapshotHistory}, function() {
-      console.log('Local storage "snapshotHistory" is set to ' + JSON.stringify(tabIdSnapshotHistory));
-
-      if (connections[tabId]) {
-        console.log(`sending message to port ${tabId}. msg payload sent: `, JSON.stringify(tabIdSnapshotHistory))
-        connections[tabId].postMessage({
-          action: 'recordSnapshot',
-          payload: tabIdSnapshotHistory,
-        });
-      } else {
-        // Tells content script that connection was not made
-        console.log(`error: Tab, ${tabId}, not found in connection list: ${connections}`)
-      }
-    });
+    default:
+      break;
   }
 })
 

--- a/src/extension/build/stylesheet.css
+++ b/src/extension/build/stylesheet.css
@@ -4,6 +4,12 @@ body {
   margin: 0;
   height: 100%;
 }
+
+.App, #root {
+  width: 100%;
+  height: 100%;
+}
+
 /* CONTAINERS */
 
 .MainContainer {
@@ -93,4 +99,28 @@ body {
   border: 1px solid blue;
   height: 100vh;
   width: 100vw;
+}
+
+.notFoundContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  font-size: 1.2rem;
+}
+
+.notFoundContainer p {
+  margin: 60px;
+}
+
+.notFoundContainer a {
+  color: #3578e5;
+}
+
+.logo {
+  width: 20%;
+  height: auto;
 }

--- a/src/extension/contentScript.js
+++ b/src/extension/contentScript.js
@@ -5,3 +5,15 @@ window.postMessage({ action: 'contentScriptStarted' });
 window.addEventListener('message', (msg) => {
   chrome.runtime.sendMessage(msg.data);
 });
+
+// listening for messages from the background script
+chrome.runtime.onMessage.addListener(msg => {
+  // send the message to npm package
+  const { action } = msg;
+  switch (action) {
+    case 'snapshotTimeTravel':
+      console.log('we are sending snapshotTimeTravel message to module: ', msg)
+      window.postMessage(msg);
+      break;
+  }
+});


### PR DESCRIPTION
Enables developers to force re-render their Recoil web app to a previously stored snapshot within the Recoilize chrome dev tool.


FE should post a message to chrome.runtime (background.js) with this structure:
```
{
    action: 'snapshotTimeTravel'
    tabId: <chrome tabId>
    payload: {
        snapshotIndex: <index of selected snapshot>
    }
}
```