### PR TITLE
D3 minimal viable product ready

### DIFF
--- a/src/app/components/AtomTree.jsx
+++ b/src/app/components/AtomTree.jsx
@@ -13,14 +13,20 @@ function AtomTree(props) {
   // **** REFACTOR SO YOU DONT HAVE TO PROPDRILL ****
   const [snapshotHistory, setSnapshotHistory] = useState(props.snapshotHistory);
 
-  // on multiple re-renders, clears the canvas and creates a new tree based on new atom state
+  // this state is needed so that the canvas doesn't clear on the first load
+  const [initialRender, setInitialRender] = useState(true);
+
+  // this only clears the canvas if AtomTree is already rendered on the extension
   useEffect(() => {
-    document.getElementById('canvas').innerHTML = '';
+    if (!initialRender) {
+      document.getElementById('canvas').innerHTML = '';
+    }
   });
 
   // setting the snapshotHistory state on re-renders
   useEffect(() => {
     setSnapshotHistory(props.snapshotHistory);
+    setInitialRender(false);
   });
 
   // creating the main svg container for d3 elements
@@ -100,8 +106,8 @@ function AtomTree(props) {
   g.append('g')
     .attr('fill', 'none')
     .attr('stroke', '#2bff00')
-    .attr('stroke-opacity', 0.9)
-    .attr('stroke-width', 10)
+    // .attr('stroke-opacity', 1)
+    .attr('stroke-width', 5)
     .selectAll('path')
     .data(paths)
     .join('path')
@@ -120,7 +126,7 @@ function AtomTree(props) {
   const node = g
     .append('g')
     .attr('stroke-linejoin', 'round') // no clue what this does
-    .attr('stroke-width', 3)
+    .attr('stroke-width', 1)
     .selectAll('g')
     .data(nodes)
     .join('g')
@@ -136,9 +142,29 @@ function AtomTree(props) {
     .attr('text-anchor', (d) => (d.children ? 'end' : 'start'))
     .text((d) => d.data.name)
     .style('font-size', `2rem`)
+    .style('fill', 'white')
     .clone(true)
     .lower()
-    .attr('stroke', 'white');
+    .attr('stroke', '#2bff00')
+    .attr('stroke-width', 1);
+
+  node.on('mouseover', function (d, i) {
+    if (!d.children) {
+      d3.select(this)
+        .append('text')
+        .text(JSON.stringify(d.data))
+        .style('fill', 'white')
+        .attr('x', 200)
+        .attr('y', 50)
+        .style('font-size', '3rem')
+        .attr('stroke', '#2bff00')
+        .attr('id', `popup${i}`);
+    }
+  });
+
+  node.on('mouseout', function (d, i) {
+    d3.select(`#popup${i}`).remove();
+  });
 
   useEffect(() => {
     // this allows svg to be dragged around

--- a/src/app/components/AtomTree.jsx
+++ b/src/app/components/AtomTree.jsx
@@ -20,14 +20,24 @@ function AtomTree(props) {
   useEffect(() => {
     if (!initialRender) {
       document.getElementById('canvas').innerHTML = '';
+      setSnapshotHistory(props.snapshotHistory);
     }
   });
 
-  // setting the snapshotHistory state on re-renders
   useEffect(() => {
-    setSnapshotHistory(props.snapshotHistory);
+    if (!initialRender) {
+      // console.log('d3 event', d3.zoomTransform(svgContainer.node()));
+      // console.log('node', node);
+      setZoomState(d3.zoomTransform(svgContainer.node()));
+    }
+    //setting the zoomState equal to whatever the d3.event.transform so svg canvas stays at the same zoom level on multiple renders
+    // setZoomState(zoomState);
+  }, [snapshotHistory]);
+
+  // only need to set initial render state to false one time
+  useEffect(() => {
     setInitialRender(false);
-  });
+  }, []);
 
   // creating the main svg container for d3 elements
   const svgContainer = d3
@@ -152,7 +162,7 @@ function AtomTree(props) {
     if (!d.children) {
       d3.select(this)
         .append('text')
-        .text(JSON.stringify(d.data))
+        .text(JSON.stringify(d.data, undefined, 2))
         .style('fill', 'white')
         .attr('x', 200)
         .attr('y', 50)
@@ -166,52 +176,44 @@ function AtomTree(props) {
     d3.select(`#popup${i}`).remove();
   });
 
-  useEffect(() => {
-    // this allows svg to be dragged around
-    node.call(
-      d3
-        .drag()
-        .on('start', dragStarted)
-        .on('drag', dragged)
-        .on('end', dragEnded)
-    );
+  // this allows svg to be dragged around
+  node.call(
+    d3.drag().on('start', dragStarted).on('drag', dragged).on('end', dragEnded)
+  );
 
-    // this allows the svg to have zoom functionality
-    svgContainer.call(
-      d3
-        .zoom()
-        .extent([
-          [0, 0],
-          [width, height],
-        ])
-        .scaleExtent([0, 8])
-        .on('zoom', zoomed)
-    );
+  // this allows the svg to have zoom functionality
+  svgContainer.call(
+    d3
+      .zoom()
+      .extent([
+        [0, 0],
+        [width, height],
+      ])
+      .scaleExtent([0, 8])
+      .on('zoom', zoomed)
+  );
 
-    // helpers to allow dragging
-    function dragStarted() {
-      d3.select(this).raise();
-      g.attr('cursor', 'grabbing');
-    }
+  // helpers to allow dragging
+  function dragStarted() {
+    d3.select(this).raise();
+    g.attr('cursor', 'grabbing');
+  }
 
-    function dragged(d) {
-      d3.select(this)
-        .attr('dx', (d.x = d3.event.x))
-        .attr('dy', (d.y = d3.event.y));
-    }
+  function dragged(d) {
+    d3.select(this)
+      .attr('dx', (d.x = d3.event.x))
+      .attr('dy', (d.y = d3.event.y));
+  }
 
-    function dragEnded() {
-      g.attr('cursor', 'grab');
-    }
+  function dragEnded() {
+    g.attr('cursor', 'grab');
+  }
 
-    // helper function that allows for zooming
-    function zoomed() {
-      g.attr('transform', d3.event.transform);
+  // helper function that allows for zooming
+  function zoomed() {
+    g.attr('transform', d3.event.transform);
+  }
 
-      //setting the zoomState equal to whatever the d3.event.transform so svg canvas stays at the same zoom level on multiple renders
-      setZoomState(d3.event.transform);
-    }
-  });
   return (
     <div>
       <div className='AtomTree'>

--- a/src/extension/build/stylesheet.css
+++ b/src/extension/build/stylesheet.css
@@ -85,12 +85,14 @@ body {
 }
 
 #canvas {
-  border: 1px solid pink;
   height: 100%;
   width: 100%;
 }
 .AtomTree {
-  border: 1px solid blue;
   height: 100vh;
   width: 100vw;
+}
+
+.node-text {
+  color: white;
 }


### PR DESCRIPTION
Currently the D3 graph has bare bones functionality, except there is a small glitch that happens when tree is re-rendered for the first time. 
If a node on the AtomTree has no children, it has a hover state that displays additional information on the node.
The level of zooming and positioning on the canvas stays persistent on multiple re-renders.
Still working on styling the D3, need to create a better popup box for the additional information on hover state for the nodes. 