### PR TITLE
Package Update, Component Visualizer bugs fix

### DIFF
--- a/package/index.ts
+++ b/package/index.ts
@@ -24,7 +24,7 @@ export default function RecoilizeDebugger(props: any) {
     nodes = props.nodes;
   }
 
-  const { root } = props;
+  const {root} = props;
 
   const snapshot: any = useRecoilSnapshot();
 
@@ -59,10 +59,12 @@ export default function RecoilizeDebugger(props: any) {
   // React lifecycle hook on re-render
   useEffect(() => {
     if (!isRestoredState) {
-      const devToolData = createDevToolDataObject(filteredSnapshot);
+      setTimeout(() => {
+        const devToolData = createDevToolDataObject(filteredSnapshot);
 
-      // Post message to content script on every re-render of the developers application only if content script has started
-      sendWindowMessage('recordSnapshot', devToolData);
+        // Post message to content script on every re-render of the developers application only if content script has started
+        sendWindowMessage('recordSnapshot', devToolData);
+      }, 0);
     } else {
       isRestoredState = false;
     }
@@ -80,7 +82,9 @@ export default function RecoilizeDebugger(props: any) {
     switch (msg.data.action) {
       // Checks to see if content script has started before sending initial snapshot
       case 'contentScriptStarted':
-        const initialFilteredSnapshot = formatAtomSelectorRelationship(filteredSnapshot);
+        const initialFilteredSnapshot = formatAtomSelectorRelationship(
+          filteredSnapshot,
+        );
         const devToolData = createDevToolDataObject(initialFilteredSnapshot);
         sendWindowMessage('moduleInitialized', devToolData);
         break;
@@ -95,45 +99,48 @@ export default function RecoilizeDebugger(props: any) {
 
   // Sends window an action and payload message.
   const sendWindowMessage = (action: any, payload: any) => {
-    window.postMessage({
-      action,
-      payload,
-    }, '*');
+    window.postMessage(
+      {
+        action,
+        payload,
+      },
+      '*',
+    );
   };
 
   const createDevToolDataObject = (filteredSnapshot: any) => {
     return {
       filteredSnapshot: filteredSnapshot,
       componentAtomTree: formatFiberNodes(
-        root._reactRootContainer._internalRoot
-          .current,
+        root._reactRootContainer._internalRoot.current,
       ),
     };
   };
 
-  const formatAtomSelectorRelationship = (filteredSnapshot) => {
-    if (window.$recoilDebugStates && Array.isArray(window.$recoilDebugStates) && window.$recoilDebugStates.length){
-      let snapObj = window.$recoilDebugStates[window.$recoilDebugStates.length - 1];
-      if (snapObj.hasOwnProperty('nodeDeps')){
-        for (let [key, value] of snapObj.nodeDeps){
+  const formatAtomSelectorRelationship = filteredSnapshot => {
+    if (
+      window.$recoilDebugStates &&
+      Array.isArray(window.$recoilDebugStates) &&
+      window.$recoilDebugStates.length
+    ) {
+      let snapObj =
+        window.$recoilDebugStates[window.$recoilDebugStates.length - 1];
+      if (snapObj.hasOwnProperty('nodeDeps')) {
+        for (let [key, value] of snapObj.nodeDeps) {
           filteredSnapshot[key].nodeDeps = Array.from(value);
         }
       }
-      if (snapObj.hasOwnProperty('nodeToNodeSubscriptions')){   
-        for (let [key, value] of snapObj.nodeToNodeSubscriptions){
+      if (snapObj.hasOwnProperty('nodeToNodeSubscriptions')) {
+        for (let [key, value] of snapObj.nodeToNodeSubscriptions) {
           filteredSnapshot[key].nodeToNodeSubscriptions = Array.from(value);
         }
       }
     }
     return filteredSnapshot;
-  }
+  };
 
   // FOR TIME TRAVEL: time travels to a given snapshot, re renders application.
   const timeTravelToSnapshot = async (msg: any) => {
-    // await setRestoredState(true);
-    // await gotoSnapshot(snapshots[msg.data.payload.snapshotIndex]);
-    // await setRestoredState(false);
-
     isRestoredState = true;
     await gotoSnapshot(snapshots[msg.data.payload.snapshotIndex]);
   };

--- a/src/app/Containers/AtomComponentTreeContainer/index.tsx
+++ b/src/app/Containers/AtomComponentTreeContainer/index.tsx
@@ -17,8 +17,10 @@ const AtomComponentVisualContainer: React.FC<AtomComponentVisualContainerProps> 
   filteredCurSnap,
   componentAtomTree,
 }) => {
+  // this will be the atom or selector from the AtomSelectorLegend that the user clicked on.  an array with the ele at index 0 as the name of the atom/selector, and ele at index 1 will be 'atom' or 'selector'
   const [selectedRecoilValue, setSelectedRecoilValue] = useState([]);
 
+  // each property in the atoms or selectors object will be a property whose key is the atom or selector name, and whose value is the value of that atom or selector
   const atoms: atom = {};
   const selectors: selector = {};
   if (filteredCurSnap) {

--- a/src/app/components/AtomComponent/index.tsx
+++ b/src/app/components/AtomComponent/index.tsx
@@ -21,18 +21,6 @@ const AtomComponentVisual: React.FC<AtomComponentVisualProps> = ({
   // this state allows the canvas to stay at the zoom level on multiple re-renders
   const [{x, y, k}, setZoomState] = useState({x: 0, y: 0, k: 0});
 
-  // create objects to hold the selected atom or selector and all of it's relationships to other atoms/selectors
-  // const selectorToAtom = {};
-  // const atomToSelector = {};
-  // if (selectedRecoilValue[1] === 'selector') {
-  //   selectorToAtom[selectedRecoilValue[0]] =
-  //     filteredCurSnap[selectedRecoilValue[0]].nodeDeps;
-  // }
-  // if (selectedRecoilValue[1] === 'atom') {
-  //   atomToSelector[selectedRecoilValue[0]] =
-  //     filteredCurSnap[selectedRecoilValue[0]].nodeToNodeSubscriptions;
-  // }
-
   useEffect(() => {
     setZoomState(d3.zoomTransform(d3.select('#canvas').node()));
   }, [componentAtomTree, selectedRecoilValue]);
@@ -93,7 +81,7 @@ const AtomComponentVisual: React.FC<AtomComponentVisualProps> = ({
     // this segment places all the nodes on the canvas
     const node = g
       .append('g')
-      .attr('stroke-linejoin', 'round') // no clue what this does
+      .attr('stroke-linejoin', 'round')
       .attr('stroke-width', 1)
       .selectAll('g')
       .data(nodes)
@@ -106,16 +94,6 @@ const AtomComponentVisual: React.FC<AtomComponentVisualProps> = ({
       .append('circle')
       .attr('fill', colorComponents)
       .attr('r', determineSize);
-
-    function determineSize(d: any) {
-      if (d.data.recoilNodes.length) {
-        if (d.data.recoilNodes.includes(selectedRecoilValue[0])) {
-          return 150;
-        }
-        return 100;
-      }
-      return 50;
-    }
 
     // for each node that got created, append a text element that displays the name of the node
     node
@@ -153,26 +131,6 @@ const AtomComponentVisual: React.FC<AtomComponentVisualProps> = ({
       }
     });
 
-    function formatMouseoverXValue(recoilValue: any) {
-      if (atoms.hasOwnProperty(recoilValue)) {
-        return -300;
-      }
-      return -425;
-    }
-
-    function formatAtomSelectorText(atomOrSelector: any) {
-      let str = '';
-
-      atoms.hasOwnProperty(atomOrSelector)
-        ? (str += `ATOM ${atomOrSelector}: ${JSON.stringify(
-            atoms[atomOrSelector],
-          )}`)
-        : (str += `SELECTOR ${atomOrSelector}: ${JSON.stringify(
-            selectors[atomOrSelector],
-          )}`);
-
-      return str;
-    }
     // add mouseOut event handler that removes the popup text
     node.on('mouseout', function (d: any, i: any) {
       for (let x = 0; x < d.data.recoilNodes.length; x++) {
@@ -222,9 +180,38 @@ const AtomComponentVisual: React.FC<AtomComponentVisualProps> = ({
       g.attr('transform', d3.event.transform);
     }
 
+    function formatMouseoverXValue(recoilValue: any) {
+      if (atoms.hasOwnProperty(recoilValue)) {
+        return -300;
+      }
+      return -425;
+    }
+
+    function formatAtomSelectorText(atomOrSelector: any) {
+      let str = '';
+
+      atoms.hasOwnProperty(atomOrSelector)
+        ? (str += `ATOM ${atomOrSelector}: ${JSON.stringify(
+            atoms[atomOrSelector],
+          )}`)
+        : (str += `SELECTOR ${atomOrSelector}: ${JSON.stringify(
+            selectors[atomOrSelector],
+          )}`);
+
+      return str;
+    }
+    function determineSize(d: any) {
+      if (d.data.recoilNodes && d.data.recoilNodes.length) {
+        if (d.data.recoilNodes.includes(selectedRecoilValue[0])) {
+          return 150;
+        }
+        return 100;
+      }
+      return 50;
+    }
     function colorComponents(d: any) {
       // if component node contains recoil atoms or selectors, make it orange red or yellow, otherwise keep node gray
-      if (d.data.recoilNodes.length) {
+      if (d.data.recoilNodes && d.data.recoilNodes.length) {
         if (d.data.recoilNodes.includes(selectedRecoilValue[0])) {
           return 'white';
         }


### PR DESCRIPTION
Package updated to have setTimeout for sending snapshot (no longer one behind for ComponentTree).
Package updated to add selector/atom relationship to each other on initial app load.
Bugs fixed on component visualizer when componentVisualizer tab is open in devTool and user refreshes browser