### PR TITLE
fixed a bug where currentNode.momeoizedState is a null object

### DIFF
--- a/package/formatFiberNodes.js
+++ b/package/formatFiberNodes.js
@@ -37,6 +37,7 @@ const createAtomsSelectorArray = node => {
     if (
       currentNode.hasOwnProperty('memoizedState') &&
       typeof currentNode.memoizedState === 'object' &&
+      currentNode.memoizedState !== null &&
       !Array.isArray(currentNode.memoizedState) &&
       currentNode.memoizedState.hasOwnProperty('deps')
     ) {


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [x ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
To fix the bug encountered here:
<img width="584" alt="image" src="https://user-images.githubusercontent.com/22269057/103489298-d5c62100-4dd0-11eb-9019-dd945e59cf7b.png">
The set of logic check passes even when the currentNode.memoizedState is an object but a null object.

## Approach
<!--- How does your change address the problem? -->
Add another logic check for null.
Add
## Resources
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
