### PR TITLE
Bug Fix

### DIFF
--- a/package/formatFiberNodes.js
+++ b/package/formatFiberNodes.js
@@ -35,6 +35,7 @@ const createAtomsSelectorArray = node => {
     // if the memoizedState has a deps key, and that deps key is an array
     // then the first value of that array will be an atom or selector
     if (
+      typeof(currentNode) === 'object' &&
       currentNode.hasOwnProperty('memoizedState') &&
       typeof currentNode.memoizedState === 'object' &&
       !Array.isArray(currentNode.memoizedState) &&


### PR DESCRIPTION
Fixed bug where hasownproperty returned error when currentNode is null.

## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [X Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
Recoilize produced an error when currentNode's value was null
## Approach
Added a line to ensure that currentNode is an object before traversing through Fiber tree to get names of atoms and selectors
