### PR TITLE
"getDeps_UNSTABLE()" to "Snapshot.getInfo_UNSTABLE().deps"

### DIFF
--- a/package/index.js
+++ b/package/index.js
@@ -56,7 +56,7 @@ export default function RecoilizeDebugger(props) {
   const nodeSubscriptions = {};
 
   nodes.forEach(node => {
-    const getDeps = [...snapshot.getDeps_UNSTABLE(node)];
+    const getDeps = [...snapshot.getInfo_UNSTABLE(node).deps];
     nodeDeps[node.key] = getDeps.map(dep => dep.key);
   });
 


### PR DESCRIPTION
Snapshot.getDeps_UNSTABLE has been removed in recoil 0.2.0. This API changed to Snapshot.getInfo_UNSTABLE().deps. Recoilize needs to be updated here to be compatible with the latest recoil 0.2.0 release.

## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [x] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
Snapshot.getDeps_UNSTABLE has been removed in recoil 0.2.0. This API changed to Snapshot.getInfo_UNSTABLE().deps. Recoilize needs to be updated here to be compatible with the latest recoil 0.2.0 release.
## Approach
change to "Snapshot.getInfo_UNSTABLE().deps"
## Resources
Docs from recoil js :
https://recoiljs.org/docs/api-reference/core/Snapshot/