### PR TITLE
fix: recoilizeRoot error in react 18

### DIFF
--- a/package/index.js
+++ b/package/index.js
@@ -194,11 +194,19 @@ export default function RecoilizeDebugger(props) {
   };
 
   const createDevToolDataObject = (filteredSnapshot, diff, atomsAndSelectors) => {
+    // test `React.createRoot` first 
+    let rootFiberNode =
+    recoilizeRoot[
+      Object.keys(recoilizeRoot).find(key =>
+        key.startsWith('__reactContainer$'),
+      )
+    ] || recoilizeRoot._reactRootContainer._internalRoot.current;
+
     if (diff === undefined) {
       return {
         filteredSnapshot: filteredSnapshot,
         componentAtomTree: formatFiberNodes(
-          recoilizeRoot._reactRootContainer._internalRoot.current,
+          rootFiberNode,
         ),
         atomsAndSelectors,
       };
@@ -206,7 +214,7 @@ export default function RecoilizeDebugger(props) {
       return {
         filteredSnapshot: filteredSnapshot,
         componentAtomTree: formatFiberNodes(
-          recoilizeRoot._reactRootContainer._internalRoot.current,
+          rootFiberNode,
         ),
         indexDiff: diff,
         atomsAndSelectors,

--- a/package/index.ts
+++ b/package/index.ts
@@ -108,8 +108,12 @@ export default function RecoilizeDebugger(props: any) {
     return {
       filteredSnapshot: filteredSnapshot,
       componentAtomTree: formatFiberNodes(
-        root._reactRootContainer._internalRoot.current,
-      ),
+        // test `React.createRoot` first 
+        root[
+          Object.keys(root).find(key =>
+            key.startsWith('__reactContainer$'),
+          ) as string
+        ] || root._reactRootContainer._internalRoot.current),
     };
   };
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [x] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
React 18 can use
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
## Approach
change find source root fiber method
<!--- How does your change address the problem? -->
## Resources
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
```json
{
    "react": "^18.2.0",
    "react-dom": "^18.2.0",
    "recoil": "^0.7.3",
}
```
## Screenshot(s)
it's work.
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
![image](https://user-images.githubusercontent.com/33797740/175940892-1e77841e-9948-4e4e-8804-3ed4f3ac3083.png)
